### PR TITLE
feat(openapi-docgen): add openapi docgen and dev db setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Projector-server/src/main/java/com/bence/projector/server/Import.java
 /Songbook/*.pem
 /Songbook/*.jks
 /Projector-server/src/main/resources/static/.well-known/acme-challenge/
+mysql/

--- a/Projector-server/build.gradle
+++ b/Projector-server/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     implementationOnly 'org.apache.poi:poi-ooxml:4.1.0'
     implementationOnly group: 'org.apache.poi', name: 'poi-scratchpad', version: '4.1.0'
 
+    // OpenAPI & Swagger AutoDocs
+    // Source: https://www.baeldung.com/spring-rest-openapi-documentation
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.4'
 }
 
 sourceSets {

--- a/Projector-server/src/main/resources/application.properties
+++ b/Projector-server/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.datasource.username=songbook
 spring.datasource.password=JesusLovesYou
 spring.jpa.properties.hibernate.connection.charSet=UTF-8
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+
+springdoc.api-docs.path=/openapi

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # Projector
+
+## Auto-generated OpenAPI spec and Swagger Interactive API documentation
+
+The entire API is documented according to the OpenAPI specification.
+The spec is auto-generated from the source code and is available on the following URLs:
+
+- **OpenAPI Spec (JSON)**: http://localhost:8080/openapi
+- **OpenAPI Spec (YAML)**: http://localhost:8080/openapi.yaml
+   - This can be used to generate client SDKs
+     _e.g.:_ [Rapini](https://github.com/rametta/rapini) (React Query SDK generator)
+- **Swagger UI (interactive API docs)**: http://localhost:8080/swagger-ui.html
+
+## Dev DB (Docker-Compose)
+
+There is a `docker-compose.yml` file in the root of the project that can be used to start a MySQL database
+for development purposes.
+
+0. Install Docker and Docker Compose
+1. Run `docker-compose up -d` to start the database
+2. Run the backend application with the `spring.jpa.hibernate.ddl-auto`
+   application property (`./Projector-server/src/main/resources/application.properties`) set to `create`
+  - **NOTE:** please do not commit this change, as it may bring some unintended consequences on the production database!
+3. Kill the application (if it's not already killed by an error)
+4. Reset the `spring.jpa.hibernate.ddl-auto` property to `none`
+5. Run the application again normally
+
+These steps are necessary because the database is not initialized with the necessary tables
+when the application is started for the first time.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.3'
+services:
+  mysql:
+    image: mysql:8-debian
+    container_name: mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: JesusLovesYou
+      MYSQL_DATABASE: songbook
+      MYSQL_USER: songbook
+      MYSQL_PASSWORD: JesusLovesYou
+    ports:
+      - "3306:3306"
+    expose:
+      - "3306"
+    volumes:
+      - ./mysql:/var/lib/mysql


### PR DESCRIPTION
- added `docker-compose.yml` config to spin up a development db using Docker & MySQL
- added OpenAPI docgen (JSON + YAML) + Swagger interactive API docs
- documented above changes in README.md