### PR TITLE
Persist collection selection per language

### DIFF
--- a/Songbook/app/src/main/java/com/bence/songbook/ui/activity/MainActivity.java
+++ b/Songbook/app/src/main/java/com/bence/songbook/ui/activity/MainActivity.java
@@ -93,6 +93,7 @@ import com.bence.songbook.service.FavouriteSongService;
 import com.bence.songbook.service.UserService;
 import com.bence.songbook.ui.adapter.LanguageAdapter;
 import com.bence.songbook.ui.utils.CheckSongForUpdate;
+import com.bence.songbook.ui.utils.CollectionVisibilityPreferences;
 import com.bence.songbook.ui.utils.DynamicListView;
 import com.bence.songbook.ui.utils.GoogleSignInIntent;
 import com.bence.songbook.ui.utils.MainPageAdapter;
@@ -119,7 +120,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 @SuppressWarnings({"ConstantConditions", "deprecation"})
@@ -1831,6 +1835,12 @@ public class MainActivity extends BaseActivity
             return false;
         });
 
+        final MenuItem collectionsMenuItem = menu.findItem(R.id.action_collections);
+        collectionsMenuItem.setOnMenuItemClickListener(item -> {
+            onCollectionButtonClick(null);
+            return false;
+        });
+
         final SearchView mSearchView = (SearchView) searchItem.getActionView();
         searchItem.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_ALWAYS |
                 MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
@@ -2093,6 +2103,7 @@ public class MainActivity extends BaseActivity
     }
 
     private void sortCollectionBySelectedLanguages() {
+        prepareSongCollectionSelectionForPopup();
         boolean oneLanguageSelected = isOneLanguageSelected();
         LongSparseArray<Object> languageHashMap = new LongSparseArray<>(languages.size());
         for (Language language : languages) {
@@ -2131,12 +2142,26 @@ public class MainActivity extends BaseActivity
         collectionPopupWindow.setElevation(5.0f);
         Button selectButton = customView.findViewById(R.id.selectButton);
         selectButton.setOnClickListener(view -> {
+            saveCollectionVisibilityPreferencesFromCurrentSelection();
             filter();
             loadAll();
             filterPopupWindow.dismiss();
             collectionPopupWindow.dismiss();
         });
+        Button allButton = customView.findViewById(R.id.allButton);
+        allButton.setOnClickListener(view -> {
+            if (collectionListView != null && collectionListView.getAdapter() instanceof SongCollectionAdapter) {
+                ((SongCollectionAdapter) collectionListView.getAdapter()).setAllChecked(true);
+            }
+        });
+        Button noneButton = customView.findViewById(R.id.noneButton);
+        noneButton.setOnClickListener(view -> {
+            if (collectionListView != null && collectionListView.getAdapter() instanceof SongCollectionAdapter) {
+                ((SongCollectionAdapter) collectionListView.getAdapter()).setAllChecked(false);
+            }
+        });
         Collections.sort(songCollections, (o1, o2) -> Utility.compare(o2.getSongCollectionElements().size(), o1.getSongCollectionElements().size()));
+        prepareSongCollectionSelectionForPopup();
         collectionListView = customView.findViewById(R.id.listView);
         collectionPopupWindow.setBackgroundDrawable(new BitmapDrawable());
         collectionPopupWindow.setOutsideTouchable(true);
@@ -2256,18 +2281,30 @@ public class MainActivity extends BaseActivity
         HashMap<String, Boolean> addedSongsHashMap = new HashMap<>(hashMap.size());
         songs.clear();
         clearSongCollectionForSongs(hashMap.values());
-        if (ifAtLeastOneSongCollectionIsSelected()) {
-            for (SongCollection songCollection : songCollections) {
-                if (songCollection.isSelected()) {
-                    addSongCollectionElementsByHashMap(songCollection, hashMap, addedSongsHashMap, true);
-                }
+        boolean anySavedSelection = hasAnySavedCollectionSelection();
+        for (SongCollection songCollection : songCollections) {
+            boolean visibleByPreference = isCollectionVisibleByPreference(songCollection);
+            songCollection.setSelected(visibleByPreference);
+            if (visibleByPreference) {
+                addSongCollectionElementsByHashMap(songCollection, hashMap, addedSongsHashMap, true);
             }
-        } else {
-            for (SongCollection songCollection : songCollections) {
-                addSongCollectionElementsByHashMap(songCollection, hashMap, addedSongsHashMap, false);
-            }
+        }
+        if (!anySavedSelection) {
             addRestOfSongs(hashMap);
         }
+    }
+
+    private boolean hasAnySavedCollectionSelection() {
+        for (SongCollection songCollection : songCollections) {
+            Language language = songCollection.getLanguage();
+            if (language == null || language.getId() == null) {
+                continue;
+            }
+            if (CollectionVisibilityPreferences.hasSelection(this, language.getId())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void addSongCollectionElementsByHashMap(SongCollection songCollection, HashMap<String, Song> hashMap, HashMap<String, Boolean> addedSongsHashMap, boolean filteringByCollection) {
@@ -2314,13 +2351,71 @@ public class MainActivity extends BaseActivity
         }
     }
 
-    private boolean ifAtLeastOneSongCollectionIsSelected() {
+    private void prepareSongCollectionSelectionForPopup() {
+        if (songCollections == null) {
+            return;
+        }
         for (SongCollection songCollection : songCollections) {
-            if (songCollection.isSelected()) {
-                return true;
+            songCollection.setSelected(isCollectionVisibleByPreference(songCollection));
+        }
+    }
+
+    private boolean isCollectionVisibleByPreference(SongCollection songCollection) {
+        if (songCollection == null) {
+            return false;
+        }
+        Language language = songCollection.getLanguage();
+        if (language == null || language.getId() == null) {
+            return true;
+        }
+        if (!CollectionVisibilityPreferences.hasSelection(this, language.getId())) {
+            return true;
+        }
+        Long collectionId = songCollection.getId();
+        if (collectionId == null) {
+            return true;
+        }
+        Set<Long> selectedCollectionIds = CollectionVisibilityPreferences.getSelectedCollectionIds(this, language.getId());
+        return selectedCollectionIds.contains(collectionId);
+    }
+
+    private void saveCollectionVisibilityPreferencesFromCurrentSelection() {
+        if (songCollections == null) {
+            return;
+        }
+        Map<Long, List<SongCollection>> collectionsByLanguage = new HashMap<>();
+        for (SongCollection songCollection : songCollections) {
+            Language language = songCollection.getLanguage();
+            if (language == null || language.getId() == null) {
+                continue;
+            }
+            Long languageId = language.getId();
+            List<SongCollection> collections = collectionsByLanguage.get(languageId);
+            if (collections == null) {
+                collections = new ArrayList<>();
+                collectionsByLanguage.put(languageId, collections);
+            }
+            collections.add(songCollection);
+        }
+        for (Map.Entry<Long, List<SongCollection>> entry : collectionsByLanguage.entrySet()) {
+            long languageId = entry.getKey();
+            List<SongCollection> collections = entry.getValue();
+            Set<Long> selectedCollectionIds = new HashSet<>();
+            for (SongCollection songCollection : collections) {
+                Long collectionId = songCollection.getId();
+                if (collectionId == null) {
+                    continue;
+                }
+                if (songCollection.isSelected()) {
+                    selectedCollectionIds.add(collectionId);
+                }
+            }
+            if (selectedCollectionIds.isEmpty()) {
+                CollectionVisibilityPreferences.clearSelectedCollectionIds(this, languageId);
+            } else {
+                CollectionVisibilityPreferences.saveSelectedCollectionIds(this, languageId, selectedCollectionIds);
             }
         }
-        return false;
     }
 
     private void createSelectLanguagePopup() {
@@ -2768,6 +2863,13 @@ public class MainActivity extends BaseActivity
             songCollectionList.clear();
             songCollectionList.addAll(filteredSongCollections);
             this.notifyDataSetChanged();
+        }
+
+        void setAllChecked(boolean checked) {
+            for (SongCollection songCollection : songCollectionList) {
+                songCollection.setSelected(checked);
+            }
+            notifyDataSetChanged();
         }
 
         private class ViewHolder {

--- a/Songbook/app/src/main/java/com/bence/songbook/ui/utils/CollectionVisibilityPreferences.java
+++ b/Songbook/app/src/main/java/com/bence/songbook/ui/utils/CollectionVisibilityPreferences.java
@@ -1,0 +1,68 @@
+package com.bence.songbook.ui.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public final class CollectionVisibilityPreferences {
+
+    private static final String KEY_PREFIX = "collection_visibility_language_";
+
+    private CollectionVisibilityPreferences() {
+    }
+
+    public static boolean hasSelection(Context context, long languageId) {
+        return getPreferences(context).contains(getKey(languageId));
+    }
+
+    public static Set<Long> getSelectedCollectionIds(Context context, long languageId) {
+        SharedPreferences sharedPreferences = getPreferences(context);
+        Set<String> stored = sharedPreferences.getStringSet(getKey(languageId), null);
+        Set<Long> selectedCollectionIds = new HashSet<>();
+        if (stored == null) {
+            return selectedCollectionIds;
+        }
+        for (String value : stored) {
+            try {
+                selectedCollectionIds.add(Long.parseLong(value));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return selectedCollectionIds;
+    }
+
+    public static void saveSelectedCollectionIds(Context context, long languageId, Set<Long> collectionIds) {
+        SharedPreferences.Editor editor = getPreferences(context).edit();
+        if (collectionIds == null || collectionIds.isEmpty()) {
+            editor.remove(getKey(languageId));
+        } else {
+            Set<String> stored = new HashSet<>(collectionIds.size());
+            for (Long collectionId : collectionIds) {
+                if (collectionId != null) {
+                    stored.add(String.valueOf(collectionId));
+                }
+            }
+            if (stored.isEmpty()) {
+                editor.remove(getKey(languageId));
+            } else {
+                editor.putStringSet(getKey(languageId), stored);
+            }
+        }
+        editor.apply();
+    }
+
+    public static void clearSelectedCollectionIds(Context context, long languageId) {
+        getPreferences(context).edit().remove(getKey(languageId)).apply();
+    }
+
+    private static SharedPreferences getPreferences(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    private static String getKey(long languageId) {
+        return KEY_PREFIX + languageId;
+    }
+}

--- a/Songbook/app/src/main/res/layout/content_select_collection.xml
+++ b/Songbook/app/src/main/res/layout/content_select_collection.xml
@@ -12,11 +12,35 @@
         android:padding="6dp"
         android:text="@string/select"/>
 
+    <LinearLayout
+        android:id="@+id/actionButtons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/selectButton"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/allButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:padding="6dp"
+            android:text="@string/all_collections"/>
+
+        <Button
+            android:id="@+id/noneButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:padding="6dp"
+            android:text="@string/none_collections"/>
+    </LinearLayout>
+
     <ListView
         android:id="@+id/listView"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:layout_below="@+id/selectButton"/>
+        android:layout_below="@+id/actionButtons"/>
 </RelativeLayout>

--- a/Songbook/app/src/main/res/menu/main2.xml
+++ b/Songbook/app/src/main/res/menu/main2.xml
@@ -14,4 +14,10 @@
         android:title="@string/search_in_verses"
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction" />
+    <item
+        android:id="@+id/action_collections"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:title="@string/collections"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
 </menu>

--- a/Songbook/app/src/main/res/values/strings.xml
+++ b/Songbook/app/src/main/res/values/strings.xml
@@ -16,10 +16,13 @@
     <string name="language">Language</string>
     <string name="download_songs">Download songs</string>
     <string name="select_languages">Select song languages</string>
+    <string name="select_at_least_one_language">Select at least one language</string>
     <string name="downloading_songs">Downloading songs.</string>
     <string name="filter">Filter</string>
     <string name="sort">Sort</string>
     <string name="select">Select</string>
+    <string name="all_collections">ALL</string>
+    <string name="none_collections">NONE</string>
     <string name="modified_date">Modified date</string>
     <string name="ascending_by_title">Ascending by title</string>
     <string name="descending_by_title">Descending by title</string>
@@ -31,6 +34,7 @@
     <string name="light_theme">Light theme</string>
     <string name="maximum_size_of_text">Maximum size of text</string>
     <string name="collection">Collection</string>
+    <string name="collections">Collections</string>
     <string name="saving_songs">Saving songs</string>
     <string name="downloading_collections">Downloading collections</string>
     <string name="saving_collections">Saving collections</string>


### PR DESCRIPTION
Adds a local per-language collection selection setting in the song picker. The popup now remembers selected collections per language, includes ALL/NONE quick actions, and applies the saved selection when filtering and reopening the picker. This keeps the change scoped to collection visibility behavior only.