### PR TITLE
CU-86bz123a3: Detect duplicate YouTube IDs

### DIFF
--- a/projector-web/src/app/app.component.spec.ts
+++ b/projector-web/src/app/app.component.spec.ts
@@ -33,6 +33,7 @@ import { ActivateComponent } from './ui/activate/activate.component';
 import { NotificationSettingsComponent } from './ui/notification-settings/notification-settings.component';
 import { ProjectorComponent } from './ui/projector/projector.component';
 import { YoutubeVideoCheckerComponent } from './ui/youtube-video-checker/youtube-video-checker.component';
+import { DuplicateYoutubeIdsComponent } from './ui/duplicate-youtube-ids/duplicate-youtube-ids.component';
 import { ForgottenPasswordComponent } from './ui/forgotten-password/forgotten-password.component';
 import { ChangePasswordByTokenComponent } from './ui/forgotten-password/change-password-by-token/change-password-by-token.component';
 import { AccountComponent } from './ui/account/account.component';
@@ -70,6 +71,7 @@ describe('AppComponent', () => {
         NotificationSettingsComponent,
         ProjectorComponent,
         YoutubeVideoCheckerComponent,
+        DuplicateYoutubeIdsComponent,
         ForgottenPasswordComponent,
         ChangePasswordByTokenComponent,
         AccountComponent,

--- a/projector-web/src/app/app.module.ts
+++ b/projector-web/src/app/app.module.ts
@@ -100,6 +100,7 @@ import { EditTitleComponent } from './ui/edit-title/edit-title.component';
 import { AccountComponent } from './ui/account/account.component';
 import { DeleteAccountComponent } from './ui/delete-account/delete-account.component';
 import { YoutubeVideoCheckerComponent } from './ui/youtube-video-checker/youtube-video-checker.component';
+import { DuplicateYoutubeIdsComponent } from './ui/duplicate-youtube-ids/duplicate-youtube-ids.component';
 import { YoutubeIdCheckComponent } from './ui/youtube-id-check/youtube-id-check.component';
 import { SongGuidelinesComponent } from './ui/song-guidelines/song-guidelines.component';
 import { SongGuidelinesCheckerComponent } from './ui/song-guidelines-checker/song-guidelines-checker.component';
@@ -217,6 +218,7 @@ export class PlunkerMaterialModule {
     AccountComponent,
     DeleteAccountComponent,
     YoutubeVideoCheckerComponent,
+    DuplicateYoutubeIdsComponent,
     YoutubeIdCheckComponent,
     SongGuidelinesComponent,
     SongGuidelinesCheckerComponent,

--- a/projector-web/src/app/modules/app-routing.module.ts
+++ b/projector-web/src/app/modules/app-routing.module.ts
@@ -25,6 +25,7 @@ import { NewSongCollectionComponent } from '../ui/new-song-collection/new-song-c
 import { AccountComponent } from '../ui/account/account.component';
 import { DeleteAccountComponent } from '../ui/delete-account/delete-account.component';
 import { YoutubeVideoCheckerComponent } from '../ui/youtube-video-checker/youtube-video-checker.component';
+import { DuplicateYoutubeIdsComponent } from '../ui/duplicate-youtube-ids/duplicate-youtube-ids.component';
 import { WordsSpellCheckerComponent } from '../ui/words-spell-checker/words-spell-checker.component';
 import { AdminSongMaintenanceComponent } from '../ui/admin-song-maintenance/admin-song-maintenance.component';
 
@@ -69,6 +70,7 @@ export const appRoutes: Routes = [
   { path: 'user/notifications', component: NotificationSettingsComponent },
   { path: 'desktop-app', component: ProjectorComponent },
   { path: 'admin/YouTube-Video-Checker', component: YoutubeVideoCheckerComponent },
+  { path: 'admin/Duplicate-YouTube-IDs', component: DuplicateYoutubeIdsComponent },
   { path: 'admin/song-maintenance', component: AdminSongMaintenanceComponent },
   { path: 'forgottenPassword', component: ForgottenPasswordComponent },
   { path: 'changePasswordByToken', component: ChangePasswordByTokenComponent },

--- a/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.css
+++ b/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.css
@@ -1,0 +1,61 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.page-intro {
+  color: #555;
+  margin-bottom: 16px;
+}
+
+.summary {
+  font-weight: bold;
+  margin-bottom: 16px;
+}
+
+.empty {
+  color: #2e7d32;
+}
+
+.error {
+  color: #c62828;
+}
+
+.duplicate-group {
+  margin-bottom: 24px;
+}
+
+.duplicate-group h3 {
+  margin-bottom: 8px;
+}
+
+.duplicate-group .count {
+  font-weight: normal;
+  color: #666;
+  margin-left: 8px;
+}
+
+.simple-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.simple-table th,
+.simple-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.simple-table th {
+  background-color: #f2f2f2;
+  text-align: left;
+}
+
+.simple-table tbody tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.simple-table tbody tr:hover {
+  background-color: #f5f5f5;
+}

--- a/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.html
+++ b/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.html
@@ -1,0 +1,45 @@
+<div class="container">
+  <h2>Duplicate YouTube IDs</h2>
+  <p class="page-intro">
+    Songs that share the same YouTube video ID. Review each group and clear or change the ID on songs
+    where the video does not match the lyrics.
+  </p>
+
+  <div *ngIf="loading">Loading songs with YouTube links…</div>
+  <div *ngIf="loadError" class="error">{{ loadError }}</div>
+
+  <div *ngIf="!loading && !loadError">
+    <p class="summary">
+      {{ totalSongsWithYouTube }} songs with YouTube ·
+      {{ duplicateGroups.length }} duplicate ID{{ duplicateGroups.length === 1 ? '' : 's' }} ·
+      {{ duplicateSongCount }} songs involved
+    </p>
+
+    <div *ngIf="duplicateGroups.length === 0" class="empty">
+      No duplicate YouTube IDs found.
+    </div>
+
+    <div *ngFor="let group of duplicateGroups" class="duplicate-group">
+      <h3>
+        <a [href]="watchUrl(group.youtubeId)" target="_blank" rel="noopener">{{ group.youtubeId }}</a>
+        <span class="count">({{ group.songs.length }} songs)</span>
+      </h3>
+      <table class="simple-table">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Open</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let song of group.songs">
+            <td>{{ song.title }}</td>
+            <td>
+              <a [href]="songLink(song)" target="_blank" rel="noopener">Open</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.spec.ts
+++ b/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.spec.ts
@@ -1,0 +1,12 @@
+import { DuplicateYoutubeIdsComponent } from './duplicate-youtube-ids.component';
+
+describe('DuplicateYoutubeIdsComponent', () => {
+  it('should expose song and watch links', () => {
+    const component = new DuplicateYoutubeIdsComponent(
+      { setTitle: () => undefined } as any,
+      { getSongsContainingYouTube: () => ({ subscribe: () => undefined }) } as any
+    );
+    expect(component.songLink({ uuid: 'abc' })).toBe('/#/song/abc');
+    expect(component.watchUrl('abcdefghijk')).toBe('https://www.youtube.com/watch?v=abcdefghijk');
+  });
+});

--- a/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.ts
+++ b/projector-web/src/app/ui/duplicate-youtube-ids/duplicate-youtube-ids.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { Song, SongService } from '../../services/song-service.service';
+import { DuplicateYouTubeGroup, groupDuplicateYouTubeIds } from '../../util/youtube.util';
+
+@Component({
+  selector: 'app-duplicate-youtube-ids',
+  templateUrl: './duplicate-youtube-ids.component.html',
+  styleUrls: ['./duplicate-youtube-ids.component.css']
+})
+export class DuplicateYoutubeIdsComponent implements OnInit {
+
+  loading = true;
+  loadError: string = null;
+  duplicateGroups: DuplicateYouTubeGroup[] = [];
+  totalSongsWithYouTube = 0;
+
+  constructor(
+    private titleService: Title,
+    private songService: SongService,
+  ) { }
+
+  ngOnInit() {
+    this.titleService.setTitle('Duplicate YouTube IDs');
+    this.songService.getSongsContainingYouTube().subscribe(
+      (songs) => {
+        const active = songs.filter(s => !s.deleted && !s.reviewerErased);
+        this.totalSongsWithYouTube = active.length;
+        this.duplicateGroups = groupDuplicateYouTubeIds(active);
+        this.loading = false;
+      },
+      () => {
+        this.loadError = 'Could not load songs with YouTube links. Admin login required.';
+        this.loading = false;
+      }
+    );
+  }
+
+  songLink(song: Song | { uuid?: string; id?: string }): string {
+    const id = song.uuid || song.id;
+    return id ? '/#/song/' + id : '';
+  }
+
+  watchUrl(youtubeId: string): string {
+    return 'https://www.youtube.com/watch?v=' + youtubeId;
+  }
+
+  get duplicateSongCount(): number {
+    let count = 0;
+    for (const group of this.duplicateGroups) {
+      count += group.songs.length;
+    }
+    return count;
+  }
+}

--- a/projector-web/src/app/ui/menu-tabs/menu-tabs.component.ts
+++ b/projector-web/src/app/ui/menu-tabs/menu-tabs.component.ts
@@ -36,6 +36,7 @@ export class MenuTabsComponent implements OnInit {
     { link: '/user/notifications', icon: 'notifications', title: 'Notifications' },
     { link: '/desktop-app', icon: 'devices', title: 'Desktop app' },
     { link: '/admin/YouTube-Video-Checker', icon: 'fact_check', title: 'YouTube checker' },
+    { link: '/admin/Duplicate-YouTube-IDs', icon: 'content_copy', title: 'Duplicate YouTube IDs' },
     { link: '/admin/song-maintenance', icon: 'tune', title: 'Song maintenance' },
     { link: '/words-spell-checker', icon: 'spellcheck', title: 'Words spell checker' },
   ];

--- a/projector-web/src/app/ui/song/song.component.css
+++ b/projector-web/src/app/ui/song/song.component.css
@@ -144,3 +144,27 @@
   border-radius: 3px;
   transition: width 0.35s ease;
 }
+
+.youtube-duplicate-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 12px 0;
+  padding: 10px 12px;
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  color: #6d4c00;
+}
+
+.youtube-duplicate-warning mat-icon {
+  flex-shrink: 0;
+}
+
+.youtube-shared-icon {
+  color: #f9a825;
+  margin-right: 4px;
+}
+
+mat-list-item.youtube-shared {
+  background: #fffde7;
+}

--- a/projector-web/src/app/ui/song/song.component.html
+++ b/projector-web/src/app/ui/song/song.component.html
@@ -222,6 +222,14 @@
         </button>
         <div *ngIf="showSimilarities">
           <div *ngIf="similar.length>0">
+            <div *ngIf="similarSongsSharingYouTube.length > 0" class="youtube-duplicate-warning">
+              <mat-icon>warning</mat-icon>
+              <span>
+                This song shares its YouTube video ID with
+                {{ similarSongsSharingYouTube.length }} similar song{{ similarSongsSharingYouTube.length === 1 ? '' : 's' }}.
+                Confirm the video matches these lyrics; otherwise clear or change the ID on the wrong song.
+              </span>
+            </div>
             <mat-expansion-panel>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -230,8 +238,10 @@
               </mat-expansion-panel-header>
               <mat-nav-list>
                 <mat-list-item *ngFor="let song of similar" (click)="selectSecondSong(song)"
-                  [class.marked]="isInSongsByVersionGroup(song)">
+                  [class.marked]="isInSongsByVersionGroup(song)"
+                  [class.youtube-shared]="sharesYouTubeWithSimilar(song)">
                   <mat-icon *ngIf="!isInSongsByVersionGroup(song)">layers_clear</mat-icon>
+                  <mat-icon *ngIf="sharesYouTubeWithSimilar(song)" class="youtube-shared-icon" title="Shares YouTube ID">videocam</mat-icon>
                   <a>{{ song.title + " "}}</a>
                   <a href="/#/song/{{song.uuid}}" target="_blank">{{'. Open'}}</a>
                 </mat-list-item>

--- a/projector-web/src/app/ui/song/song.component.ts
+++ b/projector-web/src/app/ui/song/song.component.ts
@@ -16,7 +16,7 @@ import { Suggestion } from '../../models/suggestion';
 import { SongCollectionElementComponent } from '../song-collection-element/song.collection.element';
 import { checkAuthenticationError, ErrorUtil, generalError, openAuthenticateDialog } from '../../util/error-util';
 import { YoutubeIdCheckResult, YoutubeIdCheckResultType } from '../youtube-id-check/youtube-id-check.component';
-import { extractYouTubeVideoId } from '../../util/youtube.util';
+import { extractYouTubeVideoId, findSimilarSongsSharingYouTubeId } from '../../util/youtube.util';
 import { SongWordValidationService } from '../../services/song-word-validation.service';
 import { SongWordValidationResult } from '../../models/songWordValidationResult';
 import { ReviewedWordStatus } from '../../models/reviewedWord';
@@ -32,6 +32,7 @@ export class SongComponent implements OnInit, OnDestroy {
   editing = false;
   showSimilarities = false;
   similar: Song[];
+  similarSongsSharingYouTube: Song[] = [];
   secondSong: Song;
   receivedSimilar = false;
   markText = "Mark for version group";
@@ -289,15 +290,25 @@ export class SongComponent implements OnInit, OnDestroy {
 
   showSimilar() {
     this.similar = [];
+    this.similarSongsSharingYouTube = [];
     this.receivedSimilar = false;
     this.songService.getSimilar(this.song).subscribe((songs) => {
       this.similar = songs;
+      this.similarSongsSharingYouTube = findSimilarSongsSharingYouTubeId(this.song, songs) as Song[];
       if (songs.length > 0) {
         this.secondSong = this.similar[0];
       }
       this.receivedSimilar = true;
     });
     this.showSimilarities = true;
+  }
+
+  sharesYouTubeWithSimilar(song: Song): boolean {
+    if (!song || !this.similarSongsSharingYouTube) {
+      return false;
+    }
+    const key = song.uuid || song.id;
+    return this.similarSongsSharingYouTube.some(s => (s.uuid || s.id) === key);
   }
 
   selectSecondSong(song: Song) {

--- a/projector-web/src/app/util/youtube.util.spec.ts
+++ b/projector-web/src/app/util/youtube.util.spec.ts
@@ -1,0 +1,54 @@
+import {
+  extractYouTubeVideoId,
+  findSimilarSongsSharingYouTubeId,
+  groupDuplicateYouTubeIds
+} from './youtube.util';
+
+describe('youtube.util', () => {
+  describe('extractYouTubeVideoId', () => {
+    it('extracts bare and watch URL ids', () => {
+      expect(extractYouTubeVideoId('_MLXd_4tH48')).toBe('_MLXd_4tH48');
+      expect(extractYouTubeVideoId('https://www.youtube.com/watch?v=_MLXd_4tH48')).toBe('_MLXd_4tH48');
+    });
+  });
+
+  describe('groupDuplicateYouTubeIds', () => {
+    it('returns empty for null or unique ids', () => {
+      expect(groupDuplicateYouTubeIds(null)).toEqual([]);
+      expect(groupDuplicateYouTubeIds([
+        { id: '1', title: 'A', youtubeUrl: 'aaaaaaaaaaa' },
+        { id: '2', title: 'B', youtubeUrl: 'bbbbbbbbbbb' }
+      ])).toEqual([]);
+    });
+
+    it('groups shared ids and skips deleted songs', () => {
+      const groups = groupDuplicateYouTubeIds([
+        { id: '1', title: 'A', youtubeUrl: '_MLXd_4tH48' },
+        { id: '2', title: 'B', youtubeUrl: 'https://youtu.be/_MLXd_4tH48' },
+        { id: '3', title: 'C', youtubeUrl: '_MLXd_4tH48', deleted: true },
+        { id: '4', title: 'D', youtubeUrl: 'ccccccccccc' }
+      ]);
+      expect(groups.length).toBe(1);
+      expect(groups[0].youtubeId).toBe('_MLXd_4tH48');
+      expect(groups[0].songs.map(s => s.id)).toEqual(['1', '2']);
+    });
+  });
+
+  describe('findSimilarSongsSharingYouTubeId', () => {
+    it('finds similar songs with the same YouTube id', () => {
+      const song = { uuid: '5c88e6ea16d76100044cbd34', youtubeUrl: '_MLXd_4tH48' };
+      const similar = [
+        { uuid: '160ce13e-b648-4367-a38e-8cd27c184fb3', title: 'Nyisd meg szemed', youtubeUrl: '_MLXd_4tH48' },
+        { uuid: 'other', title: 'Other', youtubeUrl: 'ddddddddddd' }
+      ];
+      const shared = findSimilarSongsSharingYouTubeId(song, similar);
+      expect(shared.length).toBe(1);
+      expect(shared[0].uuid).toBe('160ce13e-b648-4367-a38e-8cd27c184fb3');
+    });
+
+    it('returns empty when current song has no YouTube id', () => {
+      expect(findSimilarSongsSharingYouTubeId({ uuid: '1' }, [{ uuid: '2', youtubeUrl: 'aaaaaaaaaaa' }]))
+        .toEqual([]);
+    });
+  });
+});

--- a/projector-web/src/app/util/youtube.util.ts
+++ b/projector-web/src/app/util/youtube.util.ts
@@ -52,3 +52,91 @@ export function getYouTubeUrlProblem(url: string | undefined | null): string | n
 
   return 'Please enter a YouTube URL from youtube.com or youtu.be, or paste an 11-character video ID.';
 }
+
+/** Song-like shape used when grouping shared YouTube IDs. */
+export interface YouTubeSongRef {
+  id?: string;
+  uuid?: string;
+  title?: string;
+  youtubeUrl?: string | null;
+  deleted?: boolean;
+  reviewerErased?: boolean;
+}
+
+export interface DuplicateYouTubeGroup {
+  youtubeId: string;
+  songs: YouTubeSongRef[];
+}
+
+function songRefKey(song: YouTubeSongRef): string {
+  return String(song.uuid || song.id || '');
+}
+
+/**
+ * Groups active songs that share the same YouTube video ID (2+ songs per ID).
+ * Groups are sorted by song count (desc), then by YouTube ID.
+ */
+export function groupDuplicateYouTubeIds(songs: YouTubeSongRef[] | null | undefined): DuplicateYouTubeGroup[] {
+  if (!songs || songs.length === 0) {
+    return [];
+  }
+
+  const byId = new Map<string, YouTubeSongRef[]>();
+  for (const song of songs) {
+    if (!song || song.deleted || song.reviewerErased) {
+      continue;
+    }
+    const youtubeId = extractYouTubeVideoId(song.youtubeUrl);
+    if (!youtubeId) {
+      continue;
+    }
+    let group = byId.get(youtubeId);
+    if (!group) {
+      group = [];
+      byId.set(youtubeId, group);
+    }
+    group.push(song);
+  }
+
+  const duplicates: DuplicateYouTubeGroup[] = [];
+  byId.forEach((groupSongs, youtubeId) => {
+    if (groupSongs.length >= 2) {
+      duplicates.push({ youtubeId, songs: groupSongs });
+    }
+  });
+
+  duplicates.sort((a, b) => {
+    const countDiff = b.songs.length - a.songs.length;
+    if (countDiff !== 0) {
+      return countDiff;
+    }
+    return a.youtubeId.localeCompare(b.youtubeId);
+  });
+  return duplicates;
+}
+
+/**
+ * Returns similar songs that share this song's YouTube video ID.
+ */
+export function findSimilarSongsSharingYouTubeId(
+  song: YouTubeSongRef | null | undefined,
+  similarSongs: YouTubeSongRef[] | null | undefined
+): YouTubeSongRef[] {
+  if (!song || !similarSongs || similarSongs.length === 0) {
+    return [];
+  }
+  const youtubeId = extractYouTubeVideoId(song.youtubeUrl);
+  if (!youtubeId) {
+    return [];
+  }
+  const currentKey = songRefKey(song);
+  return similarSongs.filter((similar) => {
+    if (!similar || similar.deleted || similar.reviewerErased) {
+      return false;
+    }
+    if (songRefKey(similar) && songRefKey(similar) === currentKey) {
+      return false;
+    }
+    return extractYouTubeVideoId(similar.youtubeUrl) === youtubeId;
+  });
+}


### PR DESCRIPTION
## Summary
- Admin page lists songs that share the same YouTube video ID so reviewers can clear/fix mismatches
- Song Similarities panel warns when the current song shares its YouTube ID with a similar song (covers the reported Nyisd meg szemed case)
- Shared helpers + unit coverage in `youtube.util`

## Example
Songs https://www.songpraise.com/song/5c88e6ea16d76100044cbd34 and similar `160ce13e-b648-4367-a38e-8cd27c184fb3` both use `_MLXd_4tH48`.

## Test plan
- [ ] Admin → Duplicate YouTube IDs — groups with 2+ songs appear; open links work
- [ ] Open the reported song → Similarities — warning about shared YouTube ID
- [ ] Confirm a unique-YouTube song shows no warning
- [ ] `npm run build` in projector-web (local package.json required; gitignored by `*.json`)