### PR TITLE
CU-86catrq69: Hide soft-deleted languages with no local songs

### DIFF
--- a/Songbook/app/src/main/java/com/bence/songbook/api/LanguageApiBean.java
+++ b/Songbook/app/src/main/java/com/bence/songbook/api/LanguageApiBean.java
@@ -25,6 +25,15 @@ public class LanguageApiBean {
 
     public List<Language> getLanguages() {
         Call<List<LanguageDTO>> call = languageApi.getLanguages();
+        return fetchLanguages(call);
+    }
+
+    public List<Language> getDeletedLanguages() {
+        Call<List<LanguageDTO>> call = languageApi.getDeletedLanguages();
+        return fetchLanguages(call);
+    }
+
+    private List<Language> fetchLanguages(Call<List<LanguageDTO>> call) {
         try {
             List<LanguageDTO> languageDTOs = call.execute().body();
             return languageAssembler.createModelList(languageDTOs);

--- a/Songbook/app/src/main/java/com/bence/songbook/api/retrofit/LanguageApi.java
+++ b/Songbook/app/src/main/java/com/bence/songbook/api/retrofit/LanguageApi.java
@@ -10,4 +10,7 @@ import retrofit2.http.GET;
 public interface LanguageApi {
     @GET("/api/languages")
     Call<List<LanguageDTO>> getLanguages();
+
+    @GET("/api/languages/deleted")
+    Call<List<LanguageDTO>> getDeletedLanguages();
 }

--- a/Songbook/app/src/main/java/com/bence/songbook/ui/activity/LanguagesActivity.java
+++ b/Songbook/app/src/main/java/com/bence/songbook/ui/activity/LanguagesActivity.java
@@ -21,7 +21,9 @@ import com.bence.songbook.R;
 import com.bence.songbook.api.LanguageApiBean;
 import com.bence.songbook.models.Language;
 import com.bence.songbook.repository.LanguageRepository;
+import com.bence.songbook.repository.SongRepository;
 import com.bence.songbook.repository.impl.ormLite.LanguageRepositoryImpl;
+import com.bence.songbook.repository.impl.ormLite.SongRepositoryImpl;
 import com.bence.songbook.ui.adapter.LanguageAdapter;
 import com.bence.songbook.utils.LanguageUtils;
 
@@ -107,6 +109,13 @@ public class LanguagesActivity extends BaseActivity {
             if (onlineLanguages != null) {
                 List<Language> newLanguages = LanguageUtils.findNewLanguages(languages, onlineLanguages, true);
                 languages.addAll(newLanguages);
+            }
+            List<Language> deletedLanguages = languageApi.getDeletedLanguages();
+            if (deletedLanguages != null) {
+                LanguageRepository languageRepository = new LanguageRepositoryImpl(getApplicationContext());
+                SongRepository songRepository = new SongRepositoryImpl(getApplicationContext());
+                LanguageUtils.applySoftDeletedDownloadPolicy(
+                        languages, deletedLanguages, languageRepository, songRepository);
             }
             return null;
         }

--- a/Songbook/app/src/main/java/com/bence/songbook/utils/LanguageUtils.java
+++ b/Songbook/app/src/main/java/com/bence/songbook/utils/LanguageUtils.java
@@ -1,9 +1,13 @@
 package com.bence.songbook.utils;
 
 import com.bence.songbook.models.Language;
+import com.bence.songbook.repository.LanguageRepository;
+import com.bence.songbook.repository.SongRepository;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class LanguageUtils {
 
@@ -38,5 +42,81 @@ public class LanguageUtils {
         }
         return newLanguages;
     }
-}
 
+    /**
+     * Soft-deleted server languages must leave the download UI. Local rows with no songs are
+     * removed from storage; rows that still have songs stay so local data is not orphaned.
+     */
+    public static void applySoftDeletedDownloadPolicy(List<Language> downloadLanguages,
+                                                      List<Language> deletedFromServer,
+                                                      LanguageRepository languageRepository,
+                                                      SongRepository songRepository) {
+        Set<String> softDeletedUuids = collectSoftDeletedUuids(deletedFromServer);
+        syncLocalSoftDeletedLanguages(
+                downloadLanguages, softDeletedUuids, languageRepository, songRepository);
+        removeSoftDeletedFromDownloadList(downloadLanguages, softDeletedUuids);
+    }
+
+    static Set<String> collectSoftDeletedUuids(List<Language> deletedFromServer) {
+        Set<String> softDeletedUuids = new HashSet<>();
+        if (deletedFromServer == null) {
+            return softDeletedUuids;
+        }
+        for (Language language : deletedFromServer) {
+            String uuid = language.getUuid();
+            if (uuid != null) {
+                softDeletedUuids.add(uuid);
+            }
+        }
+        return softDeletedUuids;
+    }
+
+    static void syncLocalSoftDeletedLanguages(List<Language> downloadLanguages,
+                                              Set<String> softDeletedUuids,
+                                              LanguageRepository languageRepository,
+                                              SongRepository songRepository) {
+        if (softDeletedUuids.isEmpty()) {
+            return;
+        }
+        for (Language language : downloadLanguages) {
+            String uuid = language.getUuid();
+            if (uuid == null || !softDeletedUuids.contains(uuid)) {
+                continue;
+            }
+            if (language.getSongsCount(songRepository) == 0) {
+                languageRepository.delete(language);
+                continue;
+            }
+            clearDownloadSelectionForSoftDeleted(language, languageRepository);
+        }
+    }
+
+    private static void clearDownloadSelectionForSoftDeleted(Language language,
+                                                             LanguageRepository languageRepository) {
+        boolean changed = false;
+        if (language.isSelected()) {
+            language.setSelected(false);
+            changed = true;
+        }
+        if (language.isSelectedForDownload()) {
+            language.setSelectedForDownload(false);
+            changed = true;
+        }
+        if (changed) {
+            languageRepository.save(language);
+        }
+    }
+
+    static void removeSoftDeletedFromDownloadList(List<Language> downloadLanguages,
+                                                  Set<String> softDeletedUuids) {
+        if (softDeletedUuids.isEmpty()) {
+            return;
+        }
+        for (int i = downloadLanguages.size() - 1; i >= 0; --i) {
+            String uuid = downloadLanguages.get(i).getUuid();
+            if (uuid != null && softDeletedUuids.contains(uuid)) {
+                downloadLanguages.remove(i);
+            }
+        }
+    }
+}

--- a/projector-desktop/src/main/java/projector/controller/language/DownloadLanguagesController.java
+++ b/projector-desktop/src/main/java/projector/controller/language/DownloadLanguagesController.java
@@ -156,7 +156,7 @@ public class DownloadLanguagesController {
                     continue;
                 }
                 softDeletedUuids.add(uuid);
-                deleteLocalSoftDeletedLanguageIfEmpty(languageService, uuid);
+                syncLocalSoftDeletedLanguage(languageService, uuid);
             }
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
@@ -164,7 +164,7 @@ public class DownloadLanguagesController {
         return softDeletedUuids;
     }
 
-    private void deleteLocalSoftDeletedLanguageIfEmpty(LanguageService languageService, String uuid) {
+    private void syncLocalSoftDeletedLanguage(LanguageService languageService, String uuid) {
         Language byUuid = languageService.findByUuid(uuid);
         if (byUuid == null) {
             return;

--- a/projector-desktop/src/main/java/projector/controller/language/DownloadLanguagesController.java
+++ b/projector-desktop/src/main/java/projector/controller/language/DownloadLanguagesController.java
@@ -33,8 +33,10 @@ import projector.utils.SceneUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 public class DownloadLanguagesController {
     private static final Logger LOG = LoggerFactory.getLogger(DownloadLanguagesController.class);
@@ -99,8 +101,9 @@ public class DownloadLanguagesController {
                     Platform.runLater(() -> addLanguageToVBox(onlineLanguage));
                 }
             }
-            deleteDeletedLanguages(languageApiBean);
+            Set<String> softDeletedUuids = pruneSoftDeletedLanguages(languageApiBean);
             Platform.runLater(() -> {
+                removeSoftDeletedFromDownloadList(softDeletedUuids);
                 clearLanguageListStatus();
                 updateSelectButtonState();
                 updateMigrationWarningLabel();
@@ -135,20 +138,62 @@ public class DownloadLanguagesController {
         });
     }
 
-    private void deleteDeletedLanguages(LanguageApiBean languageApiBean) {
+    /**
+     * Soft-deleted server languages must leave the download UI. Local rows with no songs are
+     * removed from storage; rows that still have songs stay so local data is not orphaned.
+     */
+    private Set<String> pruneSoftDeletedLanguages(LanguageApiBean languageApiBean) {
+        Set<String> softDeletedUuids = new HashSet<>();
         try {
             List<Language> deletedLanguages = languageApiBean.getDeletedLanguages();
-            if (deletedLanguages != null) {
-                LanguageService languageService = ServiceManager.getLanguageService();
-                for (Language language : deletedLanguages) {
-                    Language byUuid = languageService.findByUuid(language.getUuid());
-                    if (byUuid != null) {
-                        languageService.delete(byUuid);
-                    }
+            if (deletedLanguages == null) {
+                return softDeletedUuids;
+            }
+            LanguageService languageService = ServiceManager.getLanguageService();
+            for (Language language : deletedLanguages) {
+                String uuid = language.getUuid();
+                if (uuid == null) {
+                    continue;
                 }
+                softDeletedUuids.add(uuid);
+                deleteLocalSoftDeletedLanguageIfEmpty(languageService, uuid);
             }
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
+        }
+        return softDeletedUuids;
+    }
+
+    private void deleteLocalSoftDeletedLanguageIfEmpty(LanguageService languageService, String uuid) {
+        Language byUuid = languageService.findByUuid(uuid);
+        if (byUuid == null) {
+            return;
+        }
+        if (byUuid.getCountedSongsSize() == 0) {
+            languageService.delete(byUuid);
+            return;
+        }
+        if (byUuid.isSelected()) {
+            byUuid.setSelected(false);
+            languageService.update(byUuid);
+        }
+    }
+
+    private void removeSoftDeletedFromDownloadList(Set<String> softDeletedUuids) {
+        if (softDeletedUuids == null || softDeletedUuids.isEmpty()) {
+            return;
+        }
+        for (int i = languages.size() - 1; i >= 0; --i) {
+            Language language = languages.get(i);
+            String uuid = language.getUuid();
+            if (uuid == null || !softDeletedUuids.contains(uuid)) {
+                continue;
+            }
+            languages.remove(i);
+            if (i < checkBoxes.size()) {
+                CheckBox checkBox = checkBoxes.remove(i);
+                listView.getChildren().remove(checkBox);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Hide soft-deleted languages from Download languages on desktop and Songbook when they have no local songs.
- Keep soft-deleted languages that still have local songs in storage, but remove them from the download UI and clear download selection.
- Reuse GET /api/languages/deleted (Songbook now calls it; desktop already did).

## Test plan
- [ ] Desktop: open Download languages online - soft-deleted zero-song languages disappear after online check
- [ ] Desktop: soft-deleted language with local songs stays usable for local data but is not offered as a download checkbox
- [ ] Songbook: Download languages - same soft-deleted zero-song duplicates disappear after sync
- [ ] Songbook: soft-deleted with local songs remains in DB / not offered for download
- [ ] Active languages still appear and download as before
